### PR TITLE
Upgrade gw deployments to nginx 1.18 stable

### DIFF
--- a/kubernetes/gateway-deployment-primary.yml
+++ b/kubernetes/gateway-deployment-primary.yml
@@ -25,7 +25,7 @@ spec:
                       - 'true'
       containers:
         - name: nginx
-          image: nginx:1.17-alpine
+          image: nginx:1.18-alpine
           imagePullPolicy: Always
           ports:
             - containerPort: 8001

--- a/kubernetes/gateway-deployment-secondary.yml
+++ b/kubernetes/gateway-deployment-secondary.yml
@@ -25,7 +25,7 @@ spec:
                       - 'true'
       containers:
         - name: nginx
-          image: nginx:1.17-alpine
+          image: nginx:1.18-alpine
           imagePullPolicy: Always
           ports:
             - containerPort: 8001


### PR DESCRIPTION
## Description

Since Nginx 1.17 is not the stable version anymore, this PR is meant to upgrade to 1.18 which is the new stable version. It came out in April and has been rock solid since then.

## Testing instructions

Create a new deployment of 1.18 and check for any breaking changes. Though I don't expect any since the vhost config is fairly simple.

## Checklist for the submitter

 - [ ] ~~Documentation updated~~
 - [ ] ~~Infrastructure overview diagram updated~~

## Checklist for reviewers

- [ ] ~~If `terraform-hisec/` was updated: someone with the "Infra Owner" role has checked the output of `terraform plan`~~

## Definition of done (for team members)

This checklist is for the person who merges this pull request. _Tick check boxes, or strike out irrelevant ones._

 - [ ] ~~If `terraform-hisec/` was updated: someone with the "Infra Owner" role has run `terraform apply`~~
 - [ ] Tested in production
